### PR TITLE
authorization filter fixed

### DIFF
--- a/jbugs-business/log.out
+++ b/jbugs-business/log.out
@@ -1,0 +1,1 @@
+ro.msg.edu.jbugs.exceptions.BusinessException: test

--- a/jbugs-business/src/main/java/ro/msg/edu/jbugs/manager/impl/UserManager.java
+++ b/jbugs-business/src/main/java/ro/msg/edu/jbugs/manager/impl/UserManager.java
@@ -219,7 +219,7 @@ public class UserManager implements UserManagerRemote {
     }
 
     @Override
-    public boolean userHasPermission(Integer userId, String permission) {
+    public boolean userHasPermission(Integer userId, PermissionType permission) {
         List<PermissionType> permissions = userDao.getPermissionsOfUser(userId);
         Set<PermissionType> setPermissions = new HashSet<>();
 

--- a/jbugs-business/src/main/java/ro/msg/edu/jbugs/manager/remote/UserManagerRemote.java
+++ b/jbugs-business/src/main/java/ro/msg/edu/jbugs/manager/remote/UserManagerRemote.java
@@ -4,6 +4,7 @@ import ro.msg.edu.jbugs.dto.LoginReceivedDTO;
 import ro.msg.edu.jbugs.dto.LoginResponseUserDTO;
 import ro.msg.edu.jbugs.dto.NotificationDTO;
 import ro.msg.edu.jbugs.dto.UserDTO;
+import ro.msg.edu.jbugs.entity.types.PermissionType;
 import ro.msg.edu.jbugs.exceptions.BusinessException;
 
 import javax.ejb.Remote;
@@ -31,5 +32,5 @@ public interface UserManagerRemote {
     boolean hasBugsAssigned(Integer id) throws BusinessException;
     LoginResponseUserDTO login(LoginReceivedDTO loginReceivedDTO);
 
-    boolean userHasPermission(Integer userId, String permission);
+    boolean userHasPermission(Integer userId, PermissionType permission);
 }

--- a/jbugs-client/src/main/java/authorization/util/TokenService.java
+++ b/jbugs-client/src/main/java/authorization/util/TokenService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import ro.msg.edu.jbugs.dto.LoginResponseUserDTO;
+import ro.msg.edu.jbugs.entity.types.PermissionType;
 import ro.msg.edu.jbugs.manager.remote.UserManagerRemote;
 
 import javax.crypto.spec.SecretKeySpec;
@@ -80,7 +81,7 @@ public class TokenService {
         // and a value greater than 0 if this Date is after the Date argument.
         return (expirationDateOfToken.compareTo(now) < 0);
     }
-    public static boolean currentUserHasPermission(UserManagerRemote var_userManager, String token, String permission) {
+    public static boolean currentUserHasPermission(UserManagerRemote var_userManager, String token, PermissionType permission) {
         Integer userID = Integer.parseInt(decodeJWT(token).getId());
         return var_userManager.userHasPermission(userID, permission);
     }

--- a/jbugs-client/src/main/java/rest_app_config/filters/AuthorizationFilter.java
+++ b/jbugs-client/src/main/java/rest_app_config/filters/AuthorizationFilter.java
@@ -39,6 +39,7 @@ public class AuthorizationFilter implements ContainerRequestFilter {
             RegisteredRequestType.GET_USER_ID,
 
             RegisteredRequestType.GET_BUGS,
+            RegisteredRequestType.GET_BUG_ID,
             RegisteredRequestType.CREATE_BUG,
             RegisteredRequestType.UPDATE_BUG_ID,
             RegisteredRequestType.UPDATE_BUG,
@@ -59,6 +60,9 @@ public class AuthorizationFilter implements ContainerRequestFilter {
         }
         if (requestType.matches(RegisteredRequestType.LOGIN)) {
             return; // no auth needed
+        }
+        if (requestType.matches(RegisteredRequestType.GET_BUG_ID)) {
+            return; // no permission needed (notifications)
         }
 
         // get TOKEN from authorization header:
@@ -81,7 +85,7 @@ public class AuthorizationFilter implements ContainerRequestFilter {
     private boolean isRequestPermitted(RequestType requestType, String token) {
         for (RegisteredRequestType regReq : registeredRequestTypes) {
             if (requestType.matches(regReq)) {
-                if(isRequestOPTIONSorLOGIN(regReq)) {
+                if(isRequestOPTIONSorLOGINorGETbugID(regReq)) {
                     return true;
                 }
                 if (isRequestPermitted(token, regReq)) {
@@ -97,8 +101,9 @@ public class AuthorizationFilter implements ContainerRequestFilter {
                 .entity(msg)
                 .build());
     }
-    private boolean isRequestOPTIONSorLOGIN(RegisteredRequestType regReq){
-        if(regReq == RegisteredRequestType.OPTIONS || regReq == RegisteredRequestType.LOGIN) {
+    private boolean isRequestOPTIONSorLOGINorGETbugID(RegisteredRequestType regReq){
+        if(regReq == RegisteredRequestType.OPTIONS || regReq == RegisteredRequestType.LOGIN
+                || regReq == RegisteredRequestType.GET_BUG_ID) {
             return true;
         }
         return false;

--- a/jbugs-client/src/main/java/rest_app_config/filters/AuthorizationFilter.java
+++ b/jbugs-client/src/main/java/rest_app_config/filters/AuthorizationFilter.java
@@ -3,6 +3,7 @@ package rest_app_config.filters;
 import authorization.util.TokenService;
 import rest_app_config.type.util.RegisteredRequestType;
 import rest_app_config.type.util.RequestType;
+import ro.msg.edu.jbugs.entity.types.PermissionType;
 import ro.msg.edu.jbugs.manager.remote.UserManagerRemote;
 
 import javax.ejb.EJB;
@@ -10,6 +11,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -17,7 +19,7 @@ import java.util.Set;
 /**
  * intercepts all requests from frontend
  */
-//@Provider
+@Provider
 public class AuthorizationFilter implements ContainerRequestFilter {
 
     @EJB
@@ -40,8 +42,8 @@ public class AuthorizationFilter implements ContainerRequestFilter {
             RegisteredRequestType.CREATE_BUG,
             RegisteredRequestType.UPDATE_BUG_ID,
             RegisteredRequestType.UPDATE_BUG,
-            // rest_app_config.type.util.RegisteredRequestType.CLOSE_BUG, // TODO Miruna?
-            // rest_app_config.type.util.RegisteredRequestType.GET_USER_FOR_BUG, // TODO Miruna?
+            // RegisteredRequestType.CLOSE_BUG, // TODO Miruna?
+            // RegisteredRequestType.GET_USER_FOR_BUG, // TODO Miruna?
 
             RegisteredRequestType.SET_PERMISSIONS,
             RegisteredRequestType.GET_PERMISSIONS
@@ -49,7 +51,6 @@ public class AuthorizationFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext containerRequestContext) {
-
         RequestType requestType = new RequestType(containerRequestContext.getMethod(),
                 containerRequestContext.getUriInfo().getRequestUri().getPath());
 
@@ -103,7 +104,7 @@ public class AuthorizationFilter implements ContainerRequestFilter {
         return false;
     }
     private boolean isRequestPermitted(String token, RegisteredRequestType regReq){
-        if (TokenService.currentUserHasPermission(userManager, token, regReq.getPermission())) {
+        if (TokenService.currentUserHasPermission(userManager, token, PermissionType.get(regReq.getPermission()))) {
             return true;
         }
         return false;

--- a/jbugs-client/src/main/java/rest_app_config/type/util/RegisteredRequestType.java
+++ b/jbugs-client/src/main/java/rest_app_config/type/util/RegisteredRequestType.java
@@ -18,6 +18,7 @@ public enum RegisteredRequestType {
     GET_USER_ID("GET", "/jbugs/api/users/{id}", PermissionType.USER_MANAGEMENT.getActualString()),
 
     GET_BUGS("GET", "/jbugs/api/bugs", PermissionType.BUG_MANAGEMENT.getActualString()),
+    GET_BUG_ID("GET", "/jbugs/api/bugs/{id}", ""),
     CREATE_BUG("POST", "/jbugs/api/bugs", PermissionType.BUG_MANAGEMENT.getActualString()),
     UPDATE_BUG_ID("PUT", "/jbugs/api/bugs/update-bug-status/{id}", PermissionType.BUG_MANAGEMENT.getActualString()),
     UPDATE_BUG("PUT", "/jbugs/api/bugs/update-bug/{id}", PermissionType.BUG_MANAGEMENT.getActualString()), // Sebi? method in Bug Controller

--- a/jbugs-client/src/main/test/java/authorization/util/TokenServiceTest.java
+++ b/jbugs-client/src/main/test/java/authorization/util/TokenServiceTest.java
@@ -7,8 +7,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import ro.msg.edu.jbugs.dao.UserDao;
 import ro.msg.edu.jbugs.dto.LoginResponseUserDTO;
+import ro.msg.edu.jbugs.entity.types.PermissionType;
 import ro.msg.edu.jbugs.manager.impl.UserManager;
-import ro.msg.edu.jbugs.type.PermissionType;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -62,26 +62,26 @@ public class TokenServiceTest {
 
         String token = TokenService.generateLoginToken(loginResponseUserDTO);
 
-        List<String> permissionsLIST = new ArrayList<>();
-        permissionsLIST.add(PermissionType.BUG_CLOSE.getActualString());
-        permissionsLIST.add(PermissionType.BUG_MANAGEMENT.getActualString());
-        permissionsLIST.add(PermissionType.USER_MANAGEMENT.getActualString());
+        List<PermissionType> permissionsLIST = new ArrayList<>();
+        permissionsLIST.add(PermissionType.BUG_CLOSE);
+        permissionsLIST.add(PermissionType.BUG_MANAGEMENT);
+        permissionsLIST.add(PermissionType.USER_MANAGEMENT);
 
         Set<String> permissionsSET = new HashSet<>();
-        permissionsLIST.forEach(permission -> permissionsSET.add(permission));
+        permissionsLIST.forEach(permission -> permissionsSET.add(permission.getActualString()));
 
         loginResponseUserDTO.setPermissions(permissionsSET);
 
         when(userDao.getPermissionsOfUser(1)).thenReturn(permissionsLIST);
 
         assertFalse(TokenService.currentUserHasPermission(userManager, token,
-                PermissionType.PERMISSION_MANAGEMENT.getActualString()));
+                PermissionType.PERMISSION_MANAGEMENT));
         assertTrue(TokenService.currentUserHasPermission(userManager, token,
-                PermissionType.USER_MANAGEMENT.getActualString()));
+                PermissionType.USER_MANAGEMENT));
         assertTrue(TokenService.currentUserHasPermission(userManager, token,
-                PermissionType.BUG_CLOSE.getActualString()));
+                PermissionType.BUG_CLOSE));
         assertTrue(TokenService.currentUserHasPermission(userManager, token,
-                PermissionType.BUG_MANAGEMENT.getActualString()));
+                PermissionType.BUG_MANAGEMENT));
     }
 
     @Test


### PR DESCRIPTION
updates on userDao to check for permissionType enum, not string
changes propagated in token service and authorization filter implied